### PR TITLE
Drop unused Capture::Tiny import from lazy.pm

### DIFF
--- a/lib/lazy.pm
+++ b/lib/lazy.pm
@@ -9,7 +9,6 @@ our $VERSION = '1.000001';
 use App::cpm 0.997017 ();                # CLI has no $VERSION
 use App::cpm::CLI     ();
 use Carp              qw( longmess );
-use Capture::Tiny     qw( :all );        ## no perlimports
 use Sub::Name         qw( subname );
 use Sub::Identify     qw( sub_name );
 use Try::Tiny         qw( catch try );


### PR DESCRIPTION
Closes #20.

## Changes
- Remove the unused `use Capture::Tiny qw( :all );` line (and its `## no perlimports` annotation) from `lib/lazy.pm`. Nothing in the module called `capture`, `tee`, etc. — it was leftover from an earlier version.

## Notes
- `Capture::Tiny` stays in `cpanfile` / `Makefile.PL` because `t/load.t` and `t/local-install-via-args.t` still use it.

## Testing
- `perl -Ilib -c lib/lazy.pm` — passes.
- Confirmed via `grep` that no `Capture::Tiny` symbols (`capture`, `tee*`) are referenced in `lib/lazy.pm`.
- No new test added: this is a no-op symbol-table cleanup with no behavioral effect, and existing tests in `t/` already exercise the module's runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)