### PR TITLE
Drop unused 'say' from feature import

### DIFF
--- a/lib/lazy.pm
+++ b/lib/lazy.pm
@@ -2,7 +2,7 @@ package lazy;
 
 use strict;
 use warnings;
-use feature qw( say state );
+use feature qw( state );
 
 our $VERSION = '1.000001';
 


### PR DESCRIPTION
Closes #21

## Changes
- `lib/lazy.pm`: Remove unused `say` from the `feature` import. Only `state` (used in the recursion guard `state %seen`) is retained.

## Testing
- `perl -c lib/lazy.pm` passes (syntax OK)
- `require lazy` loads cleanly
- The only remaining `say` reference in the file is inside a POD example using `perl -E`, which auto-enables features independently of the module's import list — unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)