### PR TITLE
Simplify skip-pattern regexes in lazy @INC hook

### DIFF
--- a/lib/lazy.pm
+++ b/lib/lazy.pm
@@ -85,11 +85,11 @@ sub import {
         $name =~ s{/}{::}g;
         $name =~ s{\.pm\z}{};
 
-        if ( $name =~ qr{\A(?:auto::.*\.al\Z)} ) {
+        if ( $name =~ qr{\Aauto::.*\.al\z} ) {
             warn "skipping autoloader file $name";
             return 1;
         }
-        if ( $name =~ qr{\A(?:Net::DNS::Resolver::.*\Z)} ) {
+        if ( $name =~ qr{\ANet::DNS::Resolver::} ) {
             warn "skipping $name";
             return 1;
         }


### PR DESCRIPTION
Closes #24

## Changes

- `qr{\A(?:auto::.*\.al\Z)}` → `qr{\Aauto::.*\.al\z}` — drop redundant non-capturing group; switch `\Z` to `\z` (matches local convention on line 86).
- `qr{\A(?:Net::DNS::Resolver::.*\Z)}` → `qr{\ANet::DNS::Resolver::}` — drop redundant non-capturing group; drop trailing `.*\Z` (a `\A`-anchored prefix already implies "any suffix").

## Testing

- `perl -c lib/lazy.pm` — syntax OK.
- `perlcritic --profile perlcriticrc lib/lazy.pm` — clean.
- Verified regex equivalence against representative inputs (`auto::Foo::Bar.al`, `Net::DNS::Resolver::Recurse`, near-misses like `Net::DNS::ResolverFoo` and `Foo::auto::Bar.al`) — all match the same way as before.
- Existing `t/load.t` and `t/local-install-via-args.t` skip locally (require network); CI will exercise them.

No new tests added: the patterns live inside an inline `@INC` hook closure in `import()`, so testing them in isolation would require structural refactor, and the change is a behavior-preserving simplification for valid Perl module load names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)