### PR TITLE
Fix: @INC hook should return empty, not 1, for skipped modules

### DIFF
--- a/lib/lazy.pm
+++ b/lib/lazy.pm
@@ -87,15 +87,15 @@ sub import {
 
         if ( $name =~ qr{\A(?:auto::.*\.al\Z)} ) {
             warn "skipping autoloader file $name";
-            return 1;
+            return;
         }
         if ( $name =~ qr{\A(?:Net::DNS::Resolver::.*\Z)} ) {
             warn "skipping $name";
-            return 1;
+            return;
         }
         if ( $name eq 'Encode::ConfigLocal' ) {
             warn "skipping $name";
-            return 1;
+            return;
         }
 
         try {
@@ -106,7 +106,7 @@ sub import {
             warn $_;
         };
 
-        return 1;
+        return;
     };
     subname '_lazy_worker', $_lazy;
     push @INC, $_lazy, @INC;

--- a/t/load.t
+++ b/t/load.t
@@ -12,10 +12,11 @@ use Test::RequiresInternet (
 
 my ($cb) = grep { ref $_ eq 'CODE' } @INC;
 my ( $stdout, $stderr, @result ) = capture { $cb->( undef, 'Local::404' ) };
-my $ok = like( $stderr, qr{FAIL}, 'fake module not installed' );
-is_deeply( \@result, [], 'returns empty list after install attempt' );
+my $like_ok = like( $stderr, qr{FAIL}, 'fake module not installed' );
+my $is_ok
+    = is_deeply( \@result, [], 'returns empty list after install attempt' );
 
-unless ($ok) {
+unless ( $like_ok && $is_ok ) {
     diag 'STDOUT: ' . $stdout;
     diag 'STDERR: ' . $stderr;
 }

--- a/t/load.t
+++ b/t/load.t
@@ -13,6 +13,7 @@ use Test::RequiresInternet (
 my ($cb) = grep { ref $_ eq 'CODE' } @INC;
 my ( $stdout, $stderr, @result ) = capture { $cb->( undef, 'Local::404' ) };
 my $ok = like( $stderr, qr{FAIL}, 'fake module not installed' );
+is_deeply( \@result, [], 'returns empty list after install attempt' );
 
 unless ($ok) {
     diag 'STDOUT: ' . $stdout;

--- a/t/skip-branches.t
+++ b/t/skip-branches.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use lazy;
+
+use Capture::Tiny qw( capture );
+use Test::More import => [qw( done_testing is_deeply like subtest )];
+
+my ($cb) = grep { ref $_ eq 'CODE' } @INC;
+
+# Per perlfunc, an @INC code ref returning a non-reference truthy scalar is
+# interpreted as a filename to load. Skip branches must return empty so
+# require continues iterating @INC.
+
+subtest 'auto/*.al skip returns empty' => sub {
+    my ( $stdout, $stderr, @result ) = capture {
+        $cb->( undef, 'auto/Foo/Bar/baz.al' );
+    };
+    like(
+        $stderr, qr{skipping autoloader file auto::Foo::Bar::baz\.al},
+        'warns about skipping autoloader'
+    );
+    is_deeply( \@result, [], 'returns empty list, not 1' );
+};
+
+subtest 'Net::DNS::Resolver::* skip returns empty' => sub {
+    my ( $stdout, $stderr, @result ) = capture {
+        $cb->( undef, 'Net/DNS/Resolver/UnixSock.pm' );
+    };
+    like(
+        $stderr, qr{skipping Net::DNS::Resolver::UnixSock},
+        'warns about skipping Net::DNS::Resolver subclass'
+    );
+    is_deeply( \@result, [], 'returns empty list, not 1' );
+};
+
+subtest 'Encode::ConfigLocal skip returns empty' => sub {
+    my ( $stdout, $stderr, @result ) = capture {
+        $cb->( undef, 'Encode/ConfigLocal.pm' );
+    };
+    like(
+        $stderr, qr{skipping Encode::ConfigLocal},
+        'warns about skipping Encode::ConfigLocal'
+    );
+    is_deeply( \@result, [], 'returns empty list, not 1' );
+};
+
+done_testing();


### PR DESCRIPTION
Closes #22

## Changes

- `lib/lazy.pm`: change four `return 1;` statements to bare `return;`
  - Three skip branches (`auto::*.al`, `Net::DNS::Resolver::*`, `Encode::ConfigLocal`)
  - Trailing branch after the install attempt
- `t/skip-branches.t`: new regression test covering each skip path; asserts on both the stderr warning and the empty return value
- `t/load.t`: one-line extension asserting empty return after a failed install attempt, covering the trailing branch

## Why

Per `perldoc perlfunc` (under `require`), an `@INC` code-ref hook returning a non-reference truthy scalar is treated as a filename to load — not as "handled, stop searching". The intent here is the opposite: yield to `require` so it continues iterating `@INC`. Bare `return;` (matching the recursion guard already on line 84) is the correct signal.

## Testing

- `prove -lv t/skip-branches.t` — 3/3 pass
- Red-green verified: with the prior `return 1;` in place, all three skip-branch assertions fail; with the fix, all pass
- `t/load.t` and `t/local-install-via-args.t` continue to skip cleanly when no internet is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)