### PR TITLE
Drop dead $is_global var in lazy::import

### DIFF
--- a/lib/lazy.pm
+++ b/lib/lazy.pm
@@ -27,7 +27,6 @@ sub import {
     shift;
     my @args = @_;
 
-    my $is_global;
     my $local_lib;
 
     # Don't add this to @INC twice
@@ -40,9 +39,10 @@ sub import {
         local @ARGV = @args;
 
         # Stolen from App::cpm::CLI::parse_options()
+        # We only need to peek at -L here; everything else (including -g) is
+        # forwarded to App::cpm via pass_through.
         GetOptions(
             'L|local-lib-contained=s' => \$local_lib,
-            'g|global'                => \$is_global,
         );
     }
 

--- a/t/pass-through-args.t
+++ b/t/pass-through-args.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+# Pass --verbose to confirm Getopt::Long pass_through forwards arbitrary
+# App::cpm flags through lazy. -g is uninformative here because GetOptions
+# operates on a local @ARGV, so even the pre-fix 'g|global' spec did not
+# strip -g from the forwarded args (see GH #19).
+use lazy ('--verbose');
+
+use Test::More import => [qw( done_testing is ok )];
+
+my @captured_args;
+{
+    require App::cpm::CLI;
+    no warnings 'redefine';
+    *App::cpm::CLI::run = sub {
+        shift;
+        push @captured_args, [@_];
+        return 1;
+    };
+}
+
+my ($cb) = grep { ref $_ eq 'CODE' } @INC;
+$cb->( undef, 'Some::Fake::Module' );
+
+is( scalar @captured_args, 1, 'App::cpm::CLI::run was called once' );
+
+my @forwarded = @{ $captured_args[0] };
+
+ok(
+    ( grep { $_ eq '--verbose' } @forwarded ),
+    '--verbose forwarded to App::cpm via pass_through'
+);
+
+done_testing();


### PR DESCRIPTION
Closes #19

## Summary
- Removes the unused `my $is_global;` declaration and the `'g|global' => \$is_global` entry from `GetOptions` in `lib/lazy.pm`. With `Getopt::Long`'s `pass_through` already in the config, unknown flags continue to flow through to `App::cpm`.
- Pure cleanup — no behavior change. `GetOptions` runs against `local @ARGV = @args`, so `-g` was never stripped from the forwarded args; the `!$local_lib` branch then auto-injects `-g` for the default global install regardless.

## Test plan
- [x] `prove -lv t/pass-through-args.t` — new invariant test asserts `--verbose` survives the import path and reaches `App::cpm::CLI::run`.
- [x] `prove -lr t/` — full suite passes locally (network-dependent tests skip in sandbox).
- [x] `perl -c lib/lazy.pm` — clean.
- [ ] CI green (Perl 5.24–5.42).

🤖 Generated with [Claude Code](https://claude.com/claude-code)