### PR TITLE
Quote Getopt::Long in perlimports.toml

### DIFF
--- a/perlimports.toml
+++ b/perlimports.toml
@@ -10,7 +10,7 @@
 # preserve_unused disabled.
 
 cache                           = false # setting this to true is currently discouraged
-ignore_modules                  = [Getopt::Long]
+ignore_modules                  = ["Getopt::Long"]
 ignore_modules_filename         = ""
 ignore_modules_pattern          = "" # regex like "^(Foo|Foo::Bar)"
 ignore_modules_pattern_filename = ""


### PR DESCRIPTION
## Summary
- Line 13 had a bareword `[Getopt::Long]` in a TOML array — TOML requires quoted strings for array elements, so the parser errored on every `perlimports` invocation against this repo.
- One-line fix: quote the entry as `["Getopt::Long"]`.

## Test plan
- [x] `TOML::Tiny::from_toml` parses the file cleanly and `ignore_modules` deserializes to `['Getopt::Long']`.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)