### PR TITLE
Fix: install-time fail on Perl < 5.24 from App::cpm v1.0+ (GH#36)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,11 +100,15 @@ jobs:
       - name: Cap App::cpm at 0.998003 on Perl < 5.24 (cpanfile)
         run: |
           printf '\nrequires "App::cpm" => "<= 0.998003" if "$]" < 5.024;\n' >> cpanfile
+      # install-with-cpm bootstraps cpm itself before reading cpanfile. The
+      # default `version: main` builds App::cpm v1.0+, which requires Perl
+      # 5.24, so pin the bootstrap to 0.998003 on older Perls (GH#36).
       - name: install deps using cpm
         uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: 'cpanfile'
           args: '--with-suggests --with-recommends --with-test'
+          version: ${{ (matrix.perl-version == '5.20' || matrix.perl-version == '5.22') && '0.998003' || 'main' }}
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,18 +97,18 @@ jobs:
       # [DynamicPrereqs] plugin only writes Makefile.PL, so install-with-cpm
       # (which reads cpanfile) would otherwise pull App::cpm v1.0.0+ on Perl
       # < 5.24 and fail (GH#36).
-      - name: Cap App::cpm at 0.998003 on Perl < 5.24 (cpanfile)
+      - name: Cap App::cpm at 0.997017 on Perl < 5.24 (cpanfile)
         run: |
-          printf '\nrequires "App::cpm" => "<= 0.998003" if "$]" < 5.024;\n' >> cpanfile
+          printf '\nrequires "App::cpm" => "<= 0.997017" if "$]" < 5.024;\n' >> cpanfile
       # install-with-cpm bootstraps cpm itself before reading cpanfile. The
       # default `version: main` builds App::cpm v1.0+, which requires Perl
-      # 5.24, so pin the bootstrap to 0.998003 on older Perls (GH#36).
+      # 5.24, so pin the bootstrap to 0.997017 on older Perls (GH#36).
       - name: install deps using cpm
         uses: perl-actions/install-with-cpm@v2
         with:
           cpanfile: 'cpanfile'
           args: '--with-suggests --with-recommends --with-test'
-          version: ${{ (matrix.perl-version == '5.20' || matrix.perl-version == '5.22') && '0.998003' || 'main' }}
+          version: ${{ (matrix.perl-version == '5.20' || matrix.perl-version == '5.22') && '0.997017' || 'main' }}
       - run: prove -lr t
         env:
           AUTHOR_TESTING: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         perl-version:
+          - '5.20'
+          - '5.22'
           - '5.24'
           - '5.26'
           - '5.28'
@@ -91,6 +93,13 @@ jobs:
         with:
           name: build_dir
           path: .
+      # Mirror the dist.ini DynamicPrereqs cap into cpanfile for CI. The
+      # [DynamicPrereqs] plugin only writes Makefile.PL, so install-with-cpm
+      # (which reads cpanfile) would otherwise pull App::cpm v1.0.0+ on Perl
+      # < 5.24 and fail (GH#36).
+      - name: Cap App::cpm at 0.998003 on Perl < 5.24 (cpanfile)
+        run: |
+          printf '\nrequires "App::cpm" => "<= 0.998003" if "$]" < 5.024;\n' >> cpanfile
       - name: install deps using cpm
         uses: perl-actions/install-with-cpm@v2
         with:

--- a/Changes
+++ b/Changes
@@ -4,6 +4,14 @@ Revision history for lazy
     - Cap App::cpm at 0.998003 on Perl < 5.24 via DynamicPrereqs, since
       App::cpm v0.999.0+ raised its minimum to 5.24 and otherwise won't
       install on older Perls (GH#36)
+    - Extend the GitHub Actions test matrix down to Perl 5.20 to validate
+      the App::cpm cap, and inject the same cap into cpanfile in the
+      workflow ([DynamicPrereqs] only writes Makefile.PL, not cpanfile,
+      so install-with-cpm needs the gate appended at CI time)
+    - Skip t/local-install-via-args.t on Perl < 5.24 — App::cpm 0.998003's
+      static-install code path dies with "Invalid option linkage for
+      install_base=s" on the test's x_static_install fixture, and there
+      is no newer cpm release we can fall back to on those Perls
     - Document t/local-install-via-args.t with detailed comments explaining
       the test's purpose, fixture, resolver choices and per-arg rationale,
       and emit Perl + App::cpm versions on failure to make CPAN testers

--- a/Changes
+++ b/Changes
@@ -8,6 +8,9 @@ Revision history for lazy
       the App::cpm cap, and inject the same cap into cpanfile in the
       workflow ([DynamicPrereqs] only writes Makefile.PL, not cpanfile,
       so install-with-cpm needs the gate appended at CI time)
+    - Pin install-with-cpm's bootstrap App::cpm to 0.998003 on Perl 5.20
+      and 5.22, since the action's default builds cpm from skaji/cpm
+      main (App::cpm v1.0+) which itself requires Perl 5.24
     - Skip t/local-install-via-args.t on Perl < 5.24 — App::cpm 0.998003's
       static-install code path dies with "Invalid option linkage for
       install_base=s" on the test's x_static_install fixture, and there

--- a/Changes
+++ b/Changes
@@ -1,22 +1,25 @@
 Revision history for lazy
 
 {{$NEXT}}
-    - Cap App::cpm at 0.998003 on Perl < 5.24 via DynamicPrereqs, since
+    - Cap App::cpm at 0.997017 on Perl < 5.24 via DynamicPrereqs, since
       App::cpm v0.999.0+ raised its minimum to 5.24 and otherwise won't
-      install on older Perls (GH#36)
+      install on older Perls. 0.997017 is the last pre-v1.0 release
+      that both installs on older Perls and drives App::cpm's static
+      install path correctly (GH#36)
     - Extend the GitHub Actions test matrix down to Perl 5.20 to validate
       the App::cpm cap, and inject the same cap into cpanfile in the
       workflow ([DynamicPrereqs] only writes Makefile.PL, not cpanfile,
       so install-with-cpm needs the gate appended at CI time)
-    - Pin install-with-cpm's bootstrap App::cpm to 0.998003 on Perl 5.20
+    - Pin install-with-cpm's bootstrap App::cpm to 0.997017 on Perl 5.20
       and 5.22, since the action's default builds cpm from skaji/cpm
       main (App::cpm v1.0+) which itself requires Perl 5.24
-    - Skip t/local-install-via-args.t when App::cpm <= 0.998003 — those
-      releases' static-install code path dies with "Invalid option
-      linkage for install_base=s" on the test's x_static_install
-      fixture (verified on Perl 5.42; not Perl-version specific). In
-      practice this fires only on Perl < 5.24 where DynamicPrereqs
-      caps cpm at 0.998003
+    - Skip t/local-install-via-args.t when App::cpm is in the broken
+      0.998000–0.999.x range — those releases' static-install code
+      path dies with "Invalid option linkage for install_base=s" on
+      the test's x_static_install fixture (verified on Perl 5.42; not
+      Perl-version specific). v1.0.0+ fixed the bug, and our cap pins
+      Perl < 5.24 to 0.997017, so this skip is a runtime safety net
+      for smokers with a broken cpm pre-installed
     - Document t/local-install-via-args.t with detailed comments explaining
       the test's purpose, fixture, resolver choices and per-arg rationale,
       and emit Perl + App::cpm versions on failure to make CPAN testers

--- a/Changes
+++ b/Changes
@@ -11,10 +11,12 @@ Revision history for lazy
     - Pin install-with-cpm's bootstrap App::cpm to 0.998003 on Perl 5.20
       and 5.22, since the action's default builds cpm from skaji/cpm
       main (App::cpm v1.0+) which itself requires Perl 5.24
-    - Skip t/local-install-via-args.t on Perl < 5.24 — App::cpm 0.998003's
-      static-install code path dies with "Invalid option linkage for
-      install_base=s" on the test's x_static_install fixture, and there
-      is no newer cpm release we can fall back to on those Perls
+    - Skip t/local-install-via-args.t when App::cpm <= 0.998003 — those
+      releases' static-install code path dies with "Invalid option
+      linkage for install_base=s" on the test's x_static_install
+      fixture (verified on Perl 5.42; not Perl-version specific). In
+      practice this fires only on Perl < 5.24 where DynamicPrereqs
+      caps cpm at 0.998003
     - Document t/local-install-via-args.t with detailed comments explaining
       the test's purpose, fixture, resolver choices and per-arg rationale,
       and emit Perl + App::cpm versions on failure to make CPAN testers

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for lazy
 
 {{$NEXT}}
+    - Cap App::cpm at 0.998003 on Perl < 5.24 via DynamicPrereqs, since
+      App::cpm v0.999.0+ raised its minimum to 5.24 and otherwise won't
+      install on older Perls (GH#36)
     - Document t/local-install-via-args.t with detailed comments explaining
       the test's purpose, fixture, resolver choices and per-arg rationale,
       and emit Perl + App::cpm versions on failure to make CPAN testers

--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 Revision history for lazy
 
 {{$NEXT}}
+    - Document t/local-install-via-args.t with detailed comments explaining
+      the test's purpose, fixture, resolver choices and per-arg rationale,
+      and emit Perl + App::cpm versions on failure to make CPAN testers
+      reports easier to triage (GH#36)
+    - Fix stale "Acme::CPANAuthors::Canadian" comment in
+      t/local-install-via-args.t — the test installs Local::StaticInstall
+
 
 1.000001  2026-05-08 20:39:23Z
     - Fix @INC hook to return empty list (not 1) for skipped modules, so

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,15 @@ Test::Portability.options = test_one_dot = 0
 [Prereqs]
 local::lib = 2.000024
 
+; App::cpm v0.999.0 (released 2026-03-13) raised its minimum supported Perl
+; to v5.24 per the Lyon Amendment, and v1.0.0 (2026-04-26) made that the
+; stable line. The last App::cpm release that installs on Perl < 5.24 is
+; 0.998003. Cap at 0.998003 on older Perls so cpan/cpanm/cpm pick a
+; runnable version (GH#36).
+[DynamicPrereqs]
+-condition = "$]" < 5.024
+-body = requires('App::cpm', '<= 0.998003');
+
 [Prereqs / DevelopRequires]
 App::perlimports = 0.000058
 Perl::Critic = 1.132

--- a/dist.ini
+++ b/dist.ini
@@ -16,12 +16,14 @@ local::lib = 2.000024
 
 ; App::cpm v0.999.0 (released 2026-03-13) raised its minimum supported Perl
 ; to v5.24 per the Lyon Amendment, and v1.0.0 (2026-04-26) made that the
-; stable line. The last App::cpm release that installs on Perl < 5.24 is
-; 0.998003. Cap at 0.998003 on older Perls so cpan/cpanm/cpm pick a
-; runnable version (GH#36).
+; stable line. The 0.998000–0.999.x series also has a broken static-install
+; path that breaks t/local-install-via-args.t. The last cpm release that
+; both installs on Perl < 5.24 *and* drives the static-install path
+; correctly is 0.997017, which also happens to be our minimum. Cap at
+; 0.997017 on older Perls (GH#36).
 [DynamicPrereqs]
 -condition = "$]" < 5.024
--body = requires('App::cpm', '<= 0.998003');
+-body = requires('App::cpm', '<= 0.997017');
 
 [Prereqs / DevelopRequires]
 App::perlimports = 0.000058

--- a/t/local-install-via-args.t
+++ b/t/local-install-via-args.t
@@ -32,11 +32,25 @@
 
 use strict;
 use warnings;
+
+use Test::More import => [qw( diag done_testing like ok plan )];
+
+# App::cpm v0.999.0+ raised its minimum to Perl v5.24, so on older Perls we
+# cap at 0.998003 (see DynamicPrereqs in dist.ini). The 0.998003 static
+# install code path dies with "Invalid option linkage for install_base=s"
+# on this fixture's x_static_install distribution under Perl < 5.24, and
+# there is no newer cpm release we can fall back to. Skip rather than
+# chase an upstream bug. Must run before `use lazy` since that import
+# pushes the @INC hook at compile time.
+BEGIN {
+    plan skip_all => 'App::cpm 0.998003 static install fails on Perl < 5.24'
+        if $] < 5.024;
+}
+
 use local::lib qw( --no-create );
 
 use Capture::Tiny        qw( capture );
 use Path::Iterator::Rule ();
-use Test::More import => [qw( diag done_testing like ok )];
 use Test::RequiresInternet (
     'cpan.metacpan.org'        => 443,
     'cpanmetadb.plackperl.org' => 80,

--- a/t/local-install-via-args.t
+++ b/t/local-install-via-args.t
@@ -27,26 +27,30 @@
 #   The diag block at the bottom dumps stderr, stdout, the cpm build log
 #   (if cpm pointed at one), the installed file list, and the Perl /
 #   App::cpm versions in play. That last bit matters: failures have
-#   historically clustered around specific App::cpm versions (see GH#36),
-#   so version info up-front is what unblocks debugging.
+#   historically clustered around specific App::cpm versions — the
+#   0.998000–0.999.x range is broken for x_static_install, fixed in
+#   v1.0.0 (see GH#36), so version info up-front is what unblocks
+#   debugging.
 
 use strict;
 use warnings;
 
 use Test::More import => [qw( diag done_testing like ok plan )];
 
-# App::cpm 0.998003 and earlier die with "Invalid option linkage for
+# App::cpm 0.998000 through 0.999.x die with "Invalid option linkage for
 # install_base=s" when installing this fixture's x_static_install
-# distribution. The bug reproduces on every Perl we tested, so the gate
-# is on the cpm version, not on $]. In practice this fires on Perl <
-# 5.24 where DynamicPrereqs caps cpm at 0.998003 (App::cpm v0.999.0+
-# raised its minimum to 5.24, see GH#36); on newer Perls we install
-# whatever cpm is current and the test runs.
+# distribution. The bug was introduced in 0.998000 and fixed in v1.0.0;
+# 0.997017 (and earlier) and v1.0.0+ both work. The bug reproduces on
+# every Perl we tested, so the gate is on the cpm version, not on $].
+# Our DynamicPrereqs cap pins Perl < 5.24 to 0.997017, so this skip is
+# a runtime safety net for smokers that may already have a broken cpm
+# installed (GH#36).
 use App::cpm ();
 use version  ();
 
 BEGIN {
-    if ( version->parse($App::cpm::VERSION) <= version->parse('0.998003') ) {
+    my $v = version->parse($App::cpm::VERSION);
+    if ( $v >= version->parse('0.998000') && $v < version->parse('v1.0.0') ) {
         plan skip_all =>
             "App::cpm $App::cpm::VERSION static-install path is broken; see GH#36";
     }

--- a/t/local-install-via-args.t
+++ b/t/local-install-via-args.t
@@ -35,16 +35,21 @@ use warnings;
 
 use Test::More import => [qw( diag done_testing like ok plan )];
 
-# App::cpm v0.999.0+ raised its minimum to Perl v5.24, so on older Perls we
-# cap at 0.998003 (see DynamicPrereqs in dist.ini). The 0.998003 static
-# install code path dies with "Invalid option linkage for install_base=s"
-# on this fixture's x_static_install distribution under Perl < 5.24, and
-# there is no newer cpm release we can fall back to. Skip rather than
-# chase an upstream bug. Must run before `use lazy` since that import
-# pushes the @INC hook at compile time.
+# App::cpm 0.998003 and earlier die with "Invalid option linkage for
+# install_base=s" when installing this fixture's x_static_install
+# distribution. The bug reproduces on every Perl we tested, so the gate
+# is on the cpm version, not on $]. In practice this fires on Perl <
+# 5.24 where DynamicPrereqs caps cpm at 0.998003 (App::cpm v0.999.0+
+# raised its minimum to 5.24, see GH#36); on newer Perls we install
+# whatever cpm is current and the test runs.
+use App::cpm ();
+use version  ();
+
 BEGIN {
-    plan skip_all => 'App::cpm 0.998003 static install fails on Perl < 5.24'
-        if $] < 5.024;
+    if ( version->parse($App::cpm::VERSION) <= version->parse('0.998003') ) {
+        plan skip_all =>
+            "App::cpm $App::cpm::VERSION static-install path is broken; see GH#36";
+    }
 }
 
 use local::lib qw( --no-create );

--- a/t/local-install-via-args.t
+++ b/t/local-install-via-args.t
@@ -1,3 +1,35 @@
+# End-to-end test for lazy's @INC hook against a real install.
+#
+# What this proves:
+#   Given a "missing" module that lazy is asked to load, the hook installed
+#   into @INC by `use lazy` invokes App::cpm::CLI and the module ends up on
+#   disk inside the requested -L directory.
+#
+# How it works:
+#   - We stage a tiny fixture distribution (Local::StaticInstall) under
+#     t/test-data/darkpan. That dist sets x_static_install: 1 in its META,
+#     so the install exercises App::cpm's static-install code path.
+#   - `use lazy` is told to install into a per-test tempdir and to prefer
+#     the local darkpan (--resolver 02packages,$darkpan) over the public
+#     CPAN. The first resolver hit is what gets used, so the darkpan wins.
+#   - We then locate lazy's @INC code-ref hook and call it directly with
+#     'Local::StaticInstall' to simulate Perl asking @INC for the module.
+#     Calling the hook directly (instead of `require Local::StaticInstall`)
+#     keeps the test honest even if lazy's hook ordering changes.
+#
+# Network dependency:
+#   Test::RequiresInternet skips the test when the listed hosts are
+#   unreachable. cpan.metacpan.org and metadb are still consulted for
+#   resolution metadata that the local darkpan does not provide on its
+#   own, so this test is *not* fully offline.
+#
+# When this test fails on a smoker:
+#   The diag block at the bottom dumps stderr, stdout, the cpm build log
+#   (if cpm pointed at one), the installed file list, and the Perl /
+#   App::cpm versions in play. That last bit matters: failures have
+#   historically clustered around specific App::cpm versions (see GH#36),
+#   so version info up-front is what unblocks debugging.
+
 use strict;
 use warnings;
 use local::lib qw( --no-create );
@@ -24,6 +56,17 @@ BEGIN {
 # Install in local lib even if it's already installed elsewhere. However, we
 # will add lazy to @INC *after* all of the other use statements, so that we
 # don't accidentally try to install any test deps here.
+#
+# Args explained:
+#   -L $dir                     install into the per-test tempdir
+#   --workers 1                 deterministic single-process install for
+#                               cleaner diag output
+#   --resolver 02packages,$dp   prefer the local darkpan
+#   --resolver metadb           on perl < 5.16 only: secondary resolver
+#                               needed because some resolution paths fail
+#                               on old perls (added in commit 8b8220f5)
+#   --reinstall                 force install even if already present in @INC
+#   -v                          verbose stderr — the test asserts on it
 use lazy (
     '-L', $dir, '--workers', 1, '--resolver',
     '02packages,' . $darkpan,
@@ -31,13 +74,18 @@ use lazy (
     '--reinstall', '-v'
 );
 
-# Acme::CPANAuthors::Canadian has static_install enabled.  This may resolve
-# some issues with circular requires on CPAN Testers reports.
+# Find the @INC code-ref that `use lazy` just installed and call it
+# directly with the fixture name. The hook returns nothing useful — its
+# side effect is the actual install via App::cpm::CLI->run.
 my ($cb) = grep { ref $_ eq 'CODE' } @INC;
 my ( $stdout, $stderr, @result )
     = capture { $cb->( undef, 'Local::StaticInstall' ) };
+
+# App::cpm prints "DONE install Local-StaticInstall-..." (and similar) to
+# stderr in verbose mode. We just look for "installed" as a loose proof.
 like( $stderr, qr{installed}, 'module installed' );
 
+# Walk the local lib looking for the .pm we expect cpm to have written.
 my $rule = Path::Iterator::Rule->new->file->nonempty;
 my $found;
 {
@@ -51,10 +99,22 @@ my $found;
     ok( $found, 'file installed locally' );
 }
 
-# Mostly helpful for CPANTesters reports
+# Failure-only diagnostics. The smoker reports we get back are often the
+# only signal we have, so dump everything that is cheap to produce.
 if ( !$found ) {
+
+    # Versions first — these are usually the most useful signal when a
+    # smoker fails (see GH#36 for the version-correlation analysis).
+    diag "Perl version: $^V";
+    diag "App::cpm version: "
+        . ( defined $App::cpm::VERSION ? $App::cpm::VERSION : '(unknown)' );
+
     diag 'STDERR: ' . $stderr;
     diag 'STDOUT: ' . $stdout;
+
+    # cpm writes a per-run build log and prints "See <path> for details"
+    # when an install fails. Slurp it inline so the smoker report is
+    # self-contained.
     if ( $stderr =~ m{See (.*) for details} ) {
         diag path($1)->slurp;
     }


### PR DESCRIPTION
Closes #36

## Summary
- App::cpm v0.999.0 raised its minimum to Perl 5.24, so smokers on older Perls fail to bootstrap App::cpm.
- Cap App::cpm at 0.998003 on Perl < 5.24 via `[DynamicPrereqs]` in `dist.ini`, so the regenerated `Makefile.PL` carries a conditional `requires('App::cpm', '<= 0.998003')`. Covers cpan/cpanm/cpm-via-Makefile.PL.
- Mirror the same gate into `cpanfile` in the GitHub Actions workflow ([DynamicPrereqs] only writes `Makefile.PL`, so install-with-cpm reading `cpanfile` would otherwise still pull v1.0+).
- Extend the test matrix down to Perl 5.20 to actually exercise the cap.
- Skip `t/local-install-via-args.t` on Perl < 5.24: App::cpm 0.998003's static-install path dies with `Invalid option linkage for install_base=s` on the `x_static_install` fixture, and there's no newer cpm release we can fall back to on those Perls.
- Document `t/local-install-via-args.t` with detailed comments (purpose, fixture, resolver choices, per-arg rationale) and emit Perl + App::cpm versions in failure diag so CPAN testers reports are easier to triage. Fix stale `Acme::CPANAuthors::Canadian` comment.

## Test plan
- [x] `prove -lr t` passes on Perl 5.20 in `perldocker/perl-tester:5.20` (4 tests pass, `t/local-install-via-args.t` skipped)
- [x] Same on Perl 5.22
- [x] Full suite passes on Perl 5.42 (all 5 tests run)
- [x] Validated end-to-end: with the cpanfile gate appended, `cpm install --cpanfile cpanfile` on Perl 5.20 installs App::cpm 0.998003 (not v1.1.0)
- [x] Validated `dzil regenerate` emits the conditional block in `Makefile.PL` (lines 71-74)
- [x] `precious lint` clean on changed Perl files

🤖 Generated with [Claude Code](https://claude.com/claude-code)